### PR TITLE
Update GitHub Actions workflow to .NET 6 and add coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,23 +8,37 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
 
-    - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.1
-
-    - name: Install .NET Framework 4.0 Developer Pack
-      shell: powershell
-      run: |
-        Invoke-WebRequest -Uri https://download.microsoft.com/download/9/5/A/95A9616B-7A37-4AF6-BC36-D6EA96C8DAAE/dotNetFx40_Full_x86_x64.exe -OutFile dotNetFx40_Full_x86_x64.exe
-        Start-Process -FilePath .\dotNetFx40_Full_x86_x64.exe -ArgumentList '/q /norestart' -Wait
+    - name: Setup .NET 6.0
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '6.0.x'
 
     - name: Build solution
-      run: msbuild DNSLookup.sln /p:Configuration=Release
+      run: |
+        dotnet restore DNSLookup.sln
+        dotnet build DNSLookup.sln --configuration Release --no-restore
 
     - name: Run tests
-      run: Tools/NUnit/nunit.exe nDNS.Tests/bin/Release/CodeMangler.nDNS.Tests.dll
+      run: dotnet test DNSLookup.sln --configuration Release --no-build --collect:"XPlat Code Coverage" --logger trx --results-directory TestResults
+
+    - name: Upload Test Results
+      if: always() # Ensure this runs even if tests fail, to upload partial results
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-results
+        path: TestResults/**/*.trx
+
+    - name: Upload Code Coverage Report
+      if: always() # Ensure this runs even if tests fail
+      uses: actions/upload-artifact@v4
+      with:
+        name: code-coverage-report
+        path: '**/*.cobertura.xml'
+        # The glob pattern will search for cobertura.xml files in any directory.
+        # Coverlet usually outputs them within the test project directories.


### PR DESCRIPTION
This commit updates the CI workflow in `.github/workflows/main.yml`:

- Migrates from .NET Framework 4.0 and `msbuild` to .NET 6 and the `dotnet` CLI.
- Changes the runner from `windows-latest` to `ubuntu-latest`.
- Simplifies the build and test steps.
- Integrates code coverage reporting using Coverlet (`--collect:"XPlat Code Coverage"`).
- Adds steps to upload test results (TRX format) and code coverage reports (Cobertura XML format) as workflow artifacts.
- Removes the no-longer-needed MSBuild setup step.

The workflow is now more streamlined and provides valuable insights into test coverage.